### PR TITLE
Add least-minutes-ahead option 

### DIFF
--- a/cmd/bus.go
+++ b/cmd/bus.go
@@ -13,7 +13,7 @@ import (
 
 // busCmd represents the bus command
 var busCmd = &cobra.Command{
-	Use:   "bus --mta-api-key YOUR_MTA_API_KEY --stop-id YOUR_STOP_ID [--bus YOUR_I2C_BUS] [--debug]",
+	Use:   "bus --mta-api-key YOUR_MTA_API_KEY --stop-id YOUR_STOP_ID [--bus YOUR_I2C_BUS] [--debug] [--least-minutes-ahead LEAST_MINUTES_AHEAD`]",
 	Short: "Display next bus times on OLED monitor via I2C",
 	Long: `This command will pull the next bus arrival times for a specific stop from the MTA API. 	
 If the debug option is included, it will print the arrival times to the terminal output.
@@ -23,12 +23,13 @@ If the debug option is not included, it will display the arrival times on an OLE
 		stopId, _ := cmd.Flags().GetString("stop-id")
 		mtaApiKey, _ := cmd.Flags().GetString("mta-api-key")
 		debug, _ := cmd.Flags().GetBool("debug")
+		leastMinutesAhead, _ := cmd.Flags().GetInt64("least-minutes-ahead")
 
 		// gets the subway arrival data right now
 		gtfsRaw := mta.CallBusRealtimeFeedApi(mtaApiKey)
 
 		// parses out the next 4 arrival times for this stop
-		arrivalTimes := gtfs.ExtractBusStopArrivalTimes(gtfsRaw, stopId, 4)
+		arrivalTimes := gtfs.ExtractBusStopArrivalTimes(gtfsRaw, stopId, 4, leastMinutesAhead)
 
 		if debug {
 			// if debug option selected, prints arrival times to stdout
@@ -58,4 +59,5 @@ func init() {
 
 	busCmd.Flags().Int("i2c-bus", 1, "Bus for the I2C connection")
 	busCmd.Flags().Bool("debug", false, "Print output to terminal instead of OLED display")
+	busCmd.Flags().Int64("least-minutes-ahead", 0, "Minimum number of minutes into the future you want to see subways for")
 }

--- a/cmd/subway.go
+++ b/cmd/subway.go
@@ -13,7 +13,7 @@ import (
 
 // subwayCmd represents the subway command
 var subwayCmd = &cobra.Command{
-	Use:   "subway --mta-api-key YOUR_MTA_API_KEY --stop-id YOUR_STOP_ID [--bus YOUR_I2C_BUS] [--debug]",
+	Use:   "subway --mta-api-key YOUR_MTA_API_KEY --stop-id YOUR_STOP_ID [--bus YOUR_I2C_BUS] [--debug] [--least-minutes-ahead LEAST_MINUTES_AHEAD`]",
 	Short: "Display next subway times on OLED monitor via I2C",
 	Long: `This command will pull the next subway arrival times for a specific stop from the MTA API. 	
 If the debug option is included, it will print the arrival times to the terminal output.
@@ -23,12 +23,13 @@ If the debug option is not included, it will display the arrival times on an OLE
 		stopId, _ := cmd.Flags().GetString("stop-id")
 		mtaApiKey, _ := cmd.Flags().GetString("mta-api-key")
 		debug, _ := cmd.Flags().GetBool("debug")
+		leastMinutesAhead, _ := cmd.Flags().GetInt64("least-minutes-ahead")
 
 		// gets the subway arrival data right now
 		gtfsRaw := mta.CallAllSubwayRealtimeFeedApis(mtaApiKey)
 
 		// parses out the next 4 arrival times for this stop
-		arrivalTimes := gtfs.ExtractSubwayStopArrivalTimes(gtfsRaw, stopId, 4)
+		arrivalTimes := gtfs.ExtractSubwayStopArrivalTimes(gtfsRaw, stopId, 4, leastMinutesAhead)
 
 		if debug {
 			// if debug option selected, prints arrival times to stdout
@@ -58,4 +59,5 @@ func init() {
 
 	subwayCmd.Flags().Int("i2c-bus", 1, "Bus for the I2C connection")
 	subwayCmd.Flags().Bool("debug", false, "Print output to terminal instead of OLED display")
+	subwayCmd.Flags().Int64("least-minutes-ahead", 0, "Minimum number of minutes into the future you want to see subways for")
 }

--- a/internal/gtfs/formatter.go
+++ b/internal/gtfs/formatter.go
@@ -95,12 +95,12 @@ func (ae arrivalEvent) toString(currentTime int64) string {
 
 // formats a stopArrivalSnapshot as a list of strings
 // numLines argument defines how many arrival times are included
-func (sas stopArrivalSnapshot) toFormattedArrivalsList(numLines int) []string {
+func (sas stopArrivalSnapshot) toFormattedArrivalsList(numLines int, leastMinutesAhead int64) []string {
 	currentTime := time.Now().Unix()
 	formattedList := []string{}
 
 	for _, arrivalEvent := range sas.arrivalEvents {
-		if currentTime < arrivalEvent.expectedTime {
+		if currentTime+(leastMinutesAhead*60) < arrivalEvent.expectedTime {
 			formattedList = append(formattedList, arrivalEvent.toString(currentTime))
 		}
 
@@ -137,10 +137,10 @@ func busFormattedTitle(stopId string) string {
 	return getStopName(stopId)
 }
 
-func (sas stopArrivalSnapshot) busFormattedList(numLines int) []string {
-	return append([]string{busFormattedTitle(sas.stopId)}, sas.toFormattedArrivalsList(numLines)...)
+func (sas stopArrivalSnapshot) busFormattedList(numLines int, leastMinutesAhead int64) []string {
+	return append([]string{busFormattedTitle(sas.stopId)}, sas.toFormattedArrivalsList(numLines, leastMinutesAhead)...)
 }
 
-func (sas stopArrivalSnapshot) subwayFormattedList(numLines int) []string {
-	return append([]string{subwayFormattedTitle(sas.stopId)}, sas.toFormattedArrivalsList(numLines)...)
+func (sas stopArrivalSnapshot) subwayFormattedList(numLines int, leastMinutesAhead int64) []string {
+	return append([]string{subwayFormattedTitle(sas.stopId)}, sas.toFormattedArrivalsList(numLines, leastMinutesAhead)...)
 }

--- a/internal/gtfs/parser.go
+++ b/internal/gtfs/parser.go
@@ -53,11 +53,11 @@ func parse(stopId string, gtfsRaw []byte) stopArrivalSnapshot {
 }
 
 // extracts the next numLines arrival times for stopId from raw GTFS file
-func ExtractSubwayStopArrivalTimes(gtfsRaw []byte, stopId string, numLines int) []string {
-	return parse(stopId, gtfsRaw).subwayFormattedList(numLines)
+func ExtractSubwayStopArrivalTimes(gtfsRaw []byte, stopId string, numLines int, leastMinutesAhead int64) []string {
+	return parse(stopId, gtfsRaw).subwayFormattedList(numLines, leastMinutesAhead)
 }
 
 // extracts the next numLines arrival times for stopId from raw GTFS file
-func ExtractBusStopArrivalTimes(gtfsRaw []byte, stopId string, numLines int) []string {
-	return parse(stopId, gtfsRaw).busFormattedList(numLines)
+func ExtractBusStopArrivalTimes(gtfsRaw []byte, stopId string, numLines int, leastMinutesAhead int64) []string {
+	return parse(stopId, gtfsRaw).busFormattedList(numLines, leastMinutesAhead)
 }


### PR DESCRIPTION
This PR adds least-minutes-ahead as an option for subway and bus times. This will then only show subways and buses that are at least that many minutes away. This is useful in the case where the subway is far away from where you live and runs frequently. Default option is 0 so the same as before adding this.